### PR TITLE
Feat(ER-00677/ER-00863/ER-00864): Replace deprecated Smartsheet sharing, workspace, and folder APIs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         "smartools.operations",
         "smartools.types",
     ],
-    version="1.4.0",
+    version="2.0.0",
     license="MIT",
     description="A wrapper for the smartsheet-python-sdk that monkey-patches in new methods & functionality.",
     long_description=read_file("README.md"),

--- a/smartools/__init__.py
+++ b/smartools/__init__.py
@@ -42,6 +42,13 @@ for class_, base in patches:
 		except (ImportError, AttributeError):
 			pass
 
+# SmartoolsShare cannot be patched by the loop above because no other
+# smartsheet.models submodule imports Share (Result uses a dynamic lookup).
+# Patch it explicitly so that Result.result.setter picks up SmartoolsShare.
+from smartools.models.share import SmartoolsShare as _SmartoolsShare
+import smartsheet.models as _sm
+_sm.Share = _SmartoolsShare
+
 # Import Smartsheet and copy all init variables such as __gov_base__ and __api_base__.
 from smartsheet import *
 

--- a/smartools/models/__init__.py
+++ b/smartools/models/__init__.py
@@ -9,3 +9,4 @@ from .cell import SmartoolsCell
 from .column import SmartoolsColumn
 from .summary_field import SmartoolsSummaryField
 from .asset_share_paginated_result import SmartoolsAssetSharesPaginatedResult
+from .share import SmartoolsShare

--- a/smartools/models/__init__.py
+++ b/smartools/models/__init__.py
@@ -10,3 +10,4 @@ from .column import SmartoolsColumn
 from .summary_field import SmartoolsSummaryField
 from .asset_share_paginated_result import SmartoolsAssetSharesPaginatedResult
 from .share import SmartoolsShare
+from .container_children import SmartoolsContainerChildren

--- a/smartools/models/__init__.py
+++ b/smartools/models/__init__.py
@@ -8,3 +8,4 @@ from .cell_format import CellFormat
 from .cell import SmartoolsCell
 from .column import SmartoolsColumn
 from .summary_field import SmartoolsSummaryField
+from .asset_share_paginated_result import SmartoolsAssetSharesPaginatedResult

--- a/smartools/models/asset_share_paginated_result.py
+++ b/smartools/models/asset_share_paginated_result.py
@@ -1,0 +1,18 @@
+from smartsheet.models import Share
+
+
+class SmartoolsAssetSharesPaginatedResult:
+    """Result object for list_asset_shares.
+
+    Exposes .items (new unified API convention) and .data (.items alias for
+    backward compatibility with old per-asset-type list_shares callers).
+    """
+
+    def __init__(self, props, dynamic_type=None, base_obj=None):
+        self._base = base_obj
+        self.next_page_token = props.get("nextPageToken")
+        self.items = [Share(item, base_obj) for item in props.get("data", [])]
+
+    @property
+    def data(self):
+        return self.items

--- a/smartools/models/asset_share_paginated_result.py
+++ b/smartools/models/asset_share_paginated_result.py
@@ -1,4 +1,4 @@
-from smartsheet.models import Share
+from .share import SmartoolsShare
 
 
 class SmartoolsAssetSharesPaginatedResult:
@@ -6,12 +6,16 @@ class SmartoolsAssetSharesPaginatedResult:
 
     Exposes .items (new unified API convention) and .data (.items alias for
     backward compatibility with old per-asset-type list_shares callers).
+
+    The new /shares endpoint returns the share list under the "items" key;
+    the old per-asset endpoints used "data". We check "items" first.
     """
 
     def __init__(self, props, dynamic_type=None, base_obj=None):
         self._base = base_obj
         self.next_page_token = props.get("nextPageToken")
-        self.items = [Share(item, base_obj) for item in props.get("data", [])]
+        raw = props.get("items") or props.get("data", [])
+        self.items = [SmartoolsShare(item, base_obj) for item in raw]
 
     @property
     def data(self):

--- a/smartools/models/container_children.py
+++ b/smartools/models/container_children.py
@@ -1,0 +1,34 @@
+class SmartoolsContainerChildren:
+    """Parses the paginated response from /workspaces/{id}/children
+    or /folders/{id}/children.
+
+    Children are returned as a flat list with a "resourceType" field
+    distinguishing sheets, folders, reports, sights, and templates.
+
+    Raw dicts are stored (not pre-created model objects) so that TypedList
+    on the receiving Workspace/Folder can instantiate using the monkey-patched
+    model class (e.g. SmartoolsSheet) rather than the original SDK class.
+    """
+
+    def __init__(self, props, dynamic_type=None, base_obj=None):
+        self._base = base_obj
+        self.next_page_token = props.get("nextPageToken")
+
+        self.sheets = []
+        self.folders = []
+        self.reports = []
+        self.sights = []
+        self.templates = []
+
+        for item in props.get("data", []):
+            resource_type = item.get("resourceType")
+            if resource_type == "sheet":
+                self.sheets.append(item)
+            elif resource_type == "folder":
+                self.folders.append(item)
+            elif resource_type == "report":
+                self.reports.append(item)
+            elif resource_type in ("sight", "dashboard"):
+                self.sights.append(item)
+            elif resource_type == "template":
+                self.templates.append(item)

--- a/smartools/models/share.py
+++ b/smartools/models/share.py
@@ -1,0 +1,32 @@
+from smartsheet.models import Share
+
+
+class SmartoolsShare(Share):
+    """Share model that handles the new unified API's string-typed numeric IDs.
+
+    The new /shares endpoint returns userId and groupId as JSON strings
+    (e.g. "967346962622340") instead of integers. The base Share model's
+    Number validator rejects strings, so we intercept those setters here.
+
+    Monkey-patching in smartools/__init__.py will replace smartsheet.models.Share
+    with this class, so all code paths (Result, list responses) benefit
+    automatically.
+    """
+
+    @Share.user_id.setter
+    def user_id(self, value):
+        if isinstance(value, str):
+            try:
+                value = int(value)
+            except (ValueError, TypeError):
+                return
+        self._user_id.value = value
+
+    @Share.group_id.setter
+    def group_id(self, value):
+        if isinstance(value, str):
+            try:
+                value = int(value)
+            except (ValueError, TypeError):
+                return
+        self._group_id.value = value

--- a/smartools/operations/folders.py
+++ b/smartools/operations/folders.py
@@ -1,14 +1,64 @@
+from types import SimpleNamespace
+
+from smartsheet import fresh_operation
 from smartsheet.folders import Folders
-from smartsheet.models import ContainerDestination
+from smartsheet.models import ContainerDestination, Folder
 
 from smartools.types import ContainerList
 from smartools.types.enumerated_value import SmartoolsEnumeratedValue
 from smartools.models import FolderContent
 from smartools.models.enums import SmartoolsAccessLevel
+from smartools.operations.workspaces import _get_container_children
 
 from smartsheet.models import Sheet
 
 class SmartoolsFolders(Folders):
+
+	def get_folder(self, folder_id, include=None):
+		"""Get the specified Folder and its contents.
+
+		Replaces the deprecated GET /folders/{id} endpoint.
+		Uses the new /metadata + /children endpoints with token-based pagination.
+
+		Args:
+			folder_id (int): Folder ID.
+			include (list[str]): Optional elements to include.
+
+		Returns:
+			Folder
+		"""
+		_op = fresh_operation("get_folder_metadata")
+		_op["method"] = "GET"
+		_op["path"] = "/folders/" + str(folder_id) + "/metadata"
+		_op["query_params"]["include"] = include
+		prepped = self._base.prepare_request(_op)
+		folder = self._base.request(prepped, "Folder", _op)
+
+		children = _get_container_children(
+			self._base, "/folders/" + str(folder_id) + "/children"
+		)
+		folder.sheets = children.sheets
+		folder.folders = children.folders
+		folder.reports = children.reports
+		folder.sights = children.sights
+		folder.templates = children.templates
+
+		return folder
+
+	def list_folders(self, folder_id, page_size=None, page=None, include_all=None):
+		"""List subfolders within the specified folder.
+
+		Replaces deprecated GET /folders/{id}/folders and the deprecated
+		includeAll parameter. Always returns all subfolders via token-based pagination.
+
+		Returns:
+			SimpleNamespace with .data containing a list of Folder objects.
+		"""
+		children = _get_container_children(
+			self._base, "/folders/" + str(folder_id) + "/children"
+		)
+		folders = [Folder(item, self._base) for item in children.folders]
+		return SimpleNamespace(data=folders)
 
 	def list_sheets_in_folder(
 			self,

--- a/smartools/operations/reports.py
+++ b/smartools/operations/reports.py
@@ -91,6 +91,43 @@ class SmartoolsReports(Reports):
 		
 		return report
 
+	def list_shares(self, report_id, page_size=None, page=None, include_all=None):
+		"""List all shares for a report via the unified sharing API.
+
+		Replaces the deprecated Reports.list_shares endpoint.
+
+		Returns:
+			SmartoolsAssetSharesPaginatedResult: Result with .items and .data.
+		"""
+		return self._base.Sharing.list_asset_shares(
+			asset_type="report",
+			asset_id=report_id,
+			include_all=bool(include_all),
+		)
+
+	def update_share(self, report_id, share_id, share_obj):
+		"""Update a report share via the unified sharing API.
+
+		Replaces the deprecated Reports.update_share endpoint.
+		"""
+		return self._base.Sharing.update_asset_share(
+			share_obj=share_obj,
+			asset_type="report",
+			asset_id=report_id,
+			share_id=share_id,
+		)
+
+	def delete_share(self, report_id, share_id):
+		"""Delete a report share via the unified sharing API.
+
+		Replaces the deprecated Reports.delete_share endpoint.
+		"""
+		return self._base.Sharing.delete_asset_share(
+			asset_type="report",
+			asset_id=report_id,
+			share_id=share_id,
+		)
+
 	def get_access_level(
 		self,
 		report_id,

--- a/smartools/operations/reports.py
+++ b/smartools/operations/reports.py
@@ -91,6 +91,22 @@ class SmartoolsReports(Reports):
 		
 		return report
 
+	def share_report(self, report_id, share_obj, send_email=False):
+		"""Share a report via the unified sharing API.
+
+		Replaces the deprecated Reports.share_report endpoint.
+		Accepts a single Share object (old API signature) or a list.
+
+		Returns:
+			Result: Result with .result[0] containing the created Share.
+		"""
+		return self._base.Sharing.share_asset(
+			share_obj=share_obj,
+			asset_type="report",
+			asset_id=report_id,
+			send_email=send_email,
+		)
+
 	def list_shares(self, report_id, page_size=None, page=None, include_all=None):
 		"""List all shares for a report via the unified sharing API.
 

--- a/smartools/operations/sharing.py
+++ b/smartools/operations/sharing.py
@@ -1,0 +1,146 @@
+import logging
+
+from smartsheet import fresh_operation
+
+
+class SmartoolsSharing:
+    """Unified sharing operations for sheets, reports, sights, and workspaces.
+
+    Implements the Smartsheet unified sharing API (POST/GET/PATCH/DELETE /shares)
+    which replaces the deprecated per-asset-type sharing methods
+    (Sheets.list_shares, Workspaces.share_workspace, Sights.share_sight, etc.).
+    """
+
+    def __init__(self, smartsheet_obj):
+        self._base = smartsheet_obj
+        self._log = logging.getLogger(__name__)
+
+    def list_asset_shares(self, asset_type, asset_id, max_items=None, last_key=None,
+                          include_all=False):
+        """List all shares for the specified asset.
+
+        Args:
+            asset_type (str): Asset type — 'sheet', 'report', 'sight', or 'workspace'.
+            asset_id (int): Asset ID.
+            max_items (int): Maximum number of items per page.
+            last_key (str): Pagination token from a previous response.
+            include_all (bool): When True, auto-paginates to collect all shares.
+
+        Returns:
+            SmartoolsAssetSharesPaginatedResult: Result with .items and .data (alias).
+        """
+        _op = fresh_operation("list_asset_shares")
+        _op["method"] = "GET"
+        _op["path"] = "/shares"
+        _op["query_params"]["assetType"] = asset_type
+        _op["query_params"]["assetId"] = asset_id
+        _op["query_params"]["maxItems"] = max_items
+        _op["query_params"]["lastKey"] = last_key
+
+        expected = ["AssetSharesPaginatedResult", "Share"]
+        prepped = self._base.prepare_request(_op)
+        result = self._base.request(prepped, expected, _op)
+
+        if include_all:
+            while result.next_page_token:
+                next_page = self.list_asset_shares(
+                    asset_type=asset_type,
+                    asset_id=asset_id,
+                    last_key=result.next_page_token,
+                )
+                result.items.extend(next_page.items)
+                result.next_page_token = next_page.next_page_token
+
+        return result
+
+    def share_asset(self, share_obj, asset_type, asset_id, send_email=None):
+        """Share an asset with one or more users or groups.
+
+        Args:
+            share_obj (Share | list[Share]): Share object or list of Share objects.
+            asset_type (str): Asset type — 'sheet', 'report', 'sight', or 'workspace'.
+            asset_id (int): Asset ID.
+            send_email (bool): Whether to notify the user by email.
+
+        Returns:
+            Result: Result with .result[0] containing the created Share.
+        """
+        if not isinstance(share_obj, list):
+            share_obj = [share_obj]
+
+        _op = fresh_operation("share_asset")
+        _op["method"] = "POST"
+        _op["path"] = "/shares"
+        _op["query_params"]["assetType"] = asset_type
+        _op["query_params"]["assetId"] = asset_id
+        _op["query_params"]["sendEmail"] = send_email
+        _op["json"] = share_obj
+
+        expected = ["Result", "Share"]
+        prepped = self._base.prepare_request(_op)
+        return self._base.request(prepped, expected, _op)
+
+    def update_asset_share(self, share_obj, asset_type, asset_id, share_id):
+        """Update the access level of an existing share.
+
+        Args:
+            share_obj (Share): Share object with updated access_level.
+            asset_type (str): Asset type — 'sheet', 'report', 'sight', or 'workspace'.
+            asset_id (int): Asset ID.
+            share_id (str): Share ID to update.
+
+        Returns:
+            Share: The updated Share object.
+        """
+        _op = fresh_operation("update_asset_share")
+        _op["method"] = "PATCH"
+        _op["path"] = "/shares/" + str(share_id)
+        _op["query_params"]["assetType"] = asset_type
+        _op["query_params"]["assetId"] = asset_id
+        _op["json"] = share_obj
+
+        expected = "Share"
+        prepped = self._base.prepare_request(_op)
+        return self._base.request(prepped, expected, _op)
+
+    def delete_asset_share(self, asset_type, asset_id, share_id):
+        """Remove a share from an asset.
+
+        Args:
+            asset_type (str): Asset type — 'sheet', 'report', 'sight', or 'workspace'.
+            asset_id (int): Asset ID.
+            share_id (str): Share ID to delete.
+
+        Returns:
+            Result: Result object (resultCode 0 on success).
+        """
+        _op = fresh_operation("delete_asset_share")
+        _op["method"] = "DELETE"
+        _op["path"] = "/shares/" + str(share_id)
+        _op["query_params"]["assetType"] = asset_type
+        _op["query_params"]["assetId"] = asset_id
+
+        expected = ["Result", None]
+        prepped = self._base.prepare_request(_op)
+        return self._base.request(prepped, expected, _op)
+
+    def get_asset_share(self, asset_type, asset_id, share_id):
+        """Retrieve a specific share for an asset.
+
+        Args:
+            asset_type (str): Asset type — 'sheet', 'report', 'sight', or 'workspace'.
+            asset_id (int): Asset ID.
+            share_id (str): Share ID to retrieve.
+
+        Returns:
+            Share: The Share object.
+        """
+        _op = fresh_operation("get_asset_share")
+        _op["method"] = "GET"
+        _op["path"] = "/shares/" + str(share_id)
+        _op["query_params"]["assetType"] = asset_type
+        _op["query_params"]["assetId"] = asset_id
+
+        expected = "Share"
+        prepped = self._base.prepare_request(_op)
+        return self._base.request(prepped, expected, _op)

--- a/smartools/operations/sheets.py
+++ b/smartools/operations/sheets.py
@@ -302,6 +302,17 @@ class SmartoolsSheets(Sheets):
             share_id=share_id,
         )
 
+    def get_share(self, sheet_id, share_id):
+        """Get a specific sheet share via the unified sharing API.
+
+        Replaces the deprecated Sheets.get_share endpoint.
+        """
+        return self._base.Sharing.get_asset_share(
+            asset_type="sheet",
+            asset_id=sheet_id,
+            share_id=share_id,
+        )
+
     def get_access_level(
         self,
         sheet_id,

--- a/smartools/operations/sheets.py
+++ b/smartools/operations/sheets.py
@@ -246,6 +246,62 @@ class SmartoolsSheets(Sheets):
         result.status = "SUCCESS"
         return result
 
+    def list_shares(self, sheet_id, page_size=None, page=None, include_all=None,
+                    include_workspace_shares=False, access_api_level=0):
+        """List all shares for a sheet via the unified sharing API.
+
+        Replaces the deprecated Sheets.list_shares endpoint.
+        access_api_level and include_workspace_shares are accepted but ignored
+        (not supported by the new API).
+
+        Returns:
+            SmartoolsAssetSharesPaginatedResult: Result with .items and .data.
+        """
+        return self._base.Sharing.list_asset_shares(
+            asset_type="sheet",
+            asset_id=sheet_id,
+            include_all=bool(include_all),
+        )
+
+    def share_sheet(self, sheet_id, share_obj, send_email=False):
+        """Share a sheet via the unified sharing API.
+
+        Replaces the deprecated Sheets.share_sheet endpoint.
+        Accepts a single Share object (old API signature) or a list.
+
+        Returns:
+            Result: Result with .result[0] containing the created Share.
+        """
+        return self._base.Sharing.share_asset(
+            share_obj=share_obj,
+            asset_type="sheet",
+            asset_id=sheet_id,
+            send_email=send_email,
+        )
+
+    def update_share(self, sheet_id, share_id, share_obj):
+        """Update a sheet share via the unified sharing API.
+
+        Replaces the deprecated Sheets.update_share endpoint.
+        """
+        return self._base.Sharing.update_asset_share(
+            share_obj=share_obj,
+            asset_type="sheet",
+            asset_id=sheet_id,
+            share_id=share_id,
+        )
+
+    def delete_share(self, sheet_id, share_id):
+        """Delete a sheet share via the unified sharing API.
+
+        Replaces the deprecated Sheets.delete_share endpoint.
+        """
+        return self._base.Sharing.delete_asset_share(
+            asset_type="sheet",
+            asset_id=sheet_id,
+            share_id=share_id,
+        )
+
     def get_access_level(
         self,
         sheet_id,

--- a/smartools/operations/sights.py
+++ b/smartools/operations/sights.py
@@ -1,0 +1,60 @@
+from smartsheet.sights import Sights
+
+
+class SmartoolsSights(Sights):
+    """Extended Sights operations with backward-compatible sharing methods
+    routed through the unified sharing API.
+    """
+
+    def list_shares(self, sight_id, page_size=None, page=None, include_all=None):
+        """List all shares for a sight (dashboard) via the unified sharing API.
+
+        Replaces the deprecated Sights.list_shares endpoint.
+
+        Returns:
+            SmartoolsAssetSharesPaginatedResult: Result with .items and .data.
+        """
+        return self._base.Sharing.list_asset_shares(
+            asset_type="sight",
+            asset_id=sight_id,
+            include_all=bool(include_all),
+        )
+
+    def share_sight(self, sight_id, share_obj, send_email=False):
+        """Share a sight (dashboard) via the unified sharing API.
+
+        Replaces the deprecated Sights.share_sight endpoint.
+        Accepts a single Share object (old API signature) or a list.
+
+        Returns:
+            Result: Result with .result[0] containing the created Share.
+        """
+        return self._base.Sharing.share_asset(
+            share_obj=share_obj,
+            asset_type="sight",
+            asset_id=sight_id,
+            send_email=send_email,
+        )
+
+    def update_share(self, sight_id, share_id, share_obj):
+        """Update a sight share via the unified sharing API.
+
+        Replaces the deprecated Sights.update_share endpoint.
+        """
+        return self._base.Sharing.update_asset_share(
+            share_obj=share_obj,
+            asset_type="sight",
+            asset_id=sight_id,
+            share_id=share_id,
+        )
+
+    def delete_share(self, sight_id, share_id):
+        """Delete a sight share via the unified sharing API.
+
+        Replaces the deprecated Sights.delete_share endpoint.
+        """
+        return self._base.Sharing.delete_asset_share(
+            asset_type="sight",
+            asset_id=sight_id,
+            share_id=share_id,
+        )

--- a/smartools/operations/workspaces.py
+++ b/smartools/operations/workspaces.py
@@ -1,3 +1,4 @@
+from smartsheet import fresh_operation
 from smartsheet.workspaces import Workspaces
 from smartsheet.models import ContainerDestination
 from smartsheet.models import Sheet
@@ -8,6 +9,42 @@ from smartools.models import WorkspaceContent
 from smartools.models.enums import SmartoolsAccessLevel
 
 class SmartoolsWorkspaces(Workspaces):
+
+	def get_workspace(self, workspace_id, load_all=False, include=None):
+		"""Get the specified Workspace and its contents.
+
+		Replaces the deprecated loadAll=true query param. When load_all=True,
+		recursively fetches nested folder contents via individual Folders.get_folder
+		calls instead of relying on the deprecated single-request bulk load.
+
+		Args:
+			workspace_id (int): Workspace ID.
+			load_all (bool): Load all contents including nested folders.
+			include (list[str]): Optional elements to include (ownerInfo, sheetVersion, source).
+
+		Returns:
+			Workspace
+		"""
+		_op = fresh_operation("get_workspace")
+		_op["method"] = "GET"
+		_op["path"] = "/workspaces/" + str(workspace_id)
+		_op["query_params"]["include"] = include
+		prepped = self._base.prepare_request(_op)
+		workspace = self._base.request(prepped, "Workspace", _op)
+		if load_all:
+			self._populate_folders(workspace.folders)
+		return workspace
+
+	def _populate_folders(self, folders):
+		"""Recursively fetch and populate contents for each folder in the list."""
+		for folder in (folders or []):
+			folder_data = self._base.Folders.get_folder(folder.id)
+			folder.sheets = folder_data.sheets
+			folder.folders = folder_data.folders
+			folder.reports = folder_data.reports
+			folder.sights = folder_data.sights
+			folder.templates = folder_data.templates
+			self._populate_folders(folder.folders)
 
 	def list_sheets_in_workspace(
 		self,

--- a/smartools/operations/workspaces.py
+++ b/smartools/operations/workspaces.py
@@ -89,6 +89,59 @@ class SmartoolsWorkspaces(Workspaces):
 			containers.folders.extend(child.folders)
 		return containers
 
+	def list_shares(self, workspace_id, page_size=None, page=None, include_all=None):
+		"""List all shares for a workspace via the unified sharing API.
+
+		Replaces the deprecated Workspaces.list_shares endpoint.
+
+		Returns:
+			SmartoolsAssetSharesPaginatedResult: Result with .items and .data.
+		"""
+		return self._base.Sharing.list_asset_shares(
+			asset_type="workspace",
+			asset_id=workspace_id,
+			include_all=bool(include_all),
+		)
+
+	def share_workspace(self, workspace_id, share_obj, send_email=False):
+		"""Share a workspace via the unified sharing API.
+
+		Replaces the deprecated Workspaces.share_workspace endpoint.
+		Accepts a single Share object (old API signature) or a list.
+
+		Returns:
+			Result: Result with .result[0] containing the created Share.
+		"""
+		return self._base.Sharing.share_asset(
+			share_obj=share_obj,
+			asset_type="workspace",
+			asset_id=workspace_id,
+			send_email=send_email,
+		)
+
+	def update_share(self, workspace_id, share_id, share_obj):
+		"""Update a workspace share via the unified sharing API.
+
+		Replaces the deprecated Workspaces.update_share endpoint.
+		"""
+		return self._base.Sharing.update_asset_share(
+			share_obj=share_obj,
+			asset_type="workspace",
+			asset_id=workspace_id,
+			share_id=share_id,
+		)
+
+	def delete_share(self, workspace_id, share_id):
+		"""Delete a workspace share via the unified sharing API.
+
+		Replaces the deprecated Workspaces.delete_share endpoint.
+		"""
+		return self._base.Sharing.delete_asset_share(
+			asset_type="workspace",
+			asset_id=workspace_id,
+			share_id=share_id,
+		)
+
 	def get_access_level(
 		self,
 		workspace_id,

--- a/smartools/operations/workspaces.py
+++ b/smartools/operations/workspaces.py
@@ -1,6 +1,8 @@
+from types import SimpleNamespace
+
 from smartsheet import fresh_operation
 from smartsheet.workspaces import Workspaces
-from smartsheet.models import ContainerDestination
+from smartsheet.models import ContainerDestination, Folder
 from smartsheet.models import Sheet
 
 from smartools.types import ContainerList
@@ -8,14 +10,54 @@ from smartools.types.enumerated_value import SmartoolsEnumeratedValue
 from smartools.models import WorkspaceContent
 from smartools.models.enums import SmartoolsAccessLevel
 
+def _get_container_children(base, path):
+	"""Fetch all children from a /children endpoint, handling token-based pagination."""
+	all_sheets, all_folders, all_reports, all_sights, all_templates = [], [], [], [], []
+	last_key = None
+	while True:
+		_op = fresh_operation("get_children")
+		_op["method"] = "GET"
+		_op["path"] = path
+		if last_key:
+			_op["query_params"]["lastKey"] = last_key
+		prepped = base.prepare_request(_op)
+		page = base.request(prepped, ["ContainerChildren", None], _op)
+		all_sheets.extend(page.sheets)
+		all_folders.extend(page.folders)
+		all_reports.extend(page.reports)
+		all_sights.extend(page.sights)
+		all_templates.extend(page.templates)
+		if not page.next_page_token:
+			break
+		last_key = page.next_page_token
+
+	from smartools.models.container_children import SmartoolsContainerChildren
+	result = object.__new__(SmartoolsContainerChildren)
+	result.sheets, result.folders, result.reports = all_sheets, all_folders, all_reports
+	result.sights, result.templates = all_sights, all_templates
+	result.next_page_token = None
+	return result
+
+
+def _populate_folders(base, folders):
+	"""Recursively fetch and populate contents for each folder in the list."""
+	for folder in (folders or []):
+		folder_data = base.Folders.get_folder(folder.id)
+		folder.sheets = folder_data.sheets
+		folder.folders = folder_data.folders
+		folder.reports = folder_data.reports
+		folder.sights = folder_data.sights
+		folder.templates = folder_data.templates
+		_populate_folders(base, folder.folders)
+
+
 class SmartoolsWorkspaces(Workspaces):
 
 	def get_workspace(self, workspace_id, load_all=False, include=None):
 		"""Get the specified Workspace and its contents.
 
-		Replaces the deprecated loadAll=true query param. When load_all=True,
-		recursively fetches nested folder contents via individual Folders.get_folder
-		calls instead of relying on the deprecated single-request bulk load.
+		Replaces the deprecated GET /workspaces/{id} and loadAll=true param.
+		Uses the new /metadata + /children endpoints with token-based pagination.
 
 		Args:
 			workspace_id (int): Workspace ID.
@@ -25,26 +67,67 @@ class SmartoolsWorkspaces(Workspaces):
 		Returns:
 			Workspace
 		"""
-		_op = fresh_operation("get_workspace")
+		_op = fresh_operation("get_workspace_metadata")
 		_op["method"] = "GET"
-		_op["path"] = "/workspaces/" + str(workspace_id)
+		_op["path"] = "/workspaces/" + str(workspace_id) + "/metadata"
 		_op["query_params"]["include"] = include
 		prepped = self._base.prepare_request(_op)
 		workspace = self._base.request(prepped, "Workspace", _op)
+
+		children = _get_container_children(
+			self._base, "/workspaces/" + str(workspace_id) + "/children"
+		)
+		workspace.sheets = children.sheets
+		workspace.folders = children.folders
+		workspace.reports = children.reports
+		workspace.sights = children.sights
+		workspace.templates = children.templates
+
 		if load_all:
-			self._populate_folders(workspace.folders)
+			_populate_folders(self._base, workspace.folders)
+
 		return workspace
 
-	def _populate_folders(self, folders):
-		"""Recursively fetch and populate contents for each folder in the list."""
-		for folder in (folders or []):
-			folder_data = self._base.Folders.get_folder(folder.id)
-			folder.sheets = folder_data.sheets
-			folder.folders = folder_data.folders
-			folder.reports = folder_data.reports
-			folder.sights = folder_data.sights
-			folder.templates = folder_data.templates
-			self._populate_folders(folder.folders)
+	def list_workspaces(self, page_size=None, page=None, include_all=None):
+		"""List workspaces the authenticated user may access.
+
+		Replaces the deprecated includeAll parameter by iterating pages
+		automatically when include_all=True.
+
+		Returns:
+			IndexResult (single page) or SimpleNamespace with .data (all pages).
+		"""
+		if not include_all:
+			return super().list_workspaces(page_size=page_size, page=page, include_all=None)
+
+		effective_page_size = page_size or 100
+		all_workspaces = []
+		current_page = 1
+		while True:
+			result = super().list_workspaces(
+				page_size=effective_page_size, page=current_page, include_all=None
+			)
+			all_workspaces.extend(result.data)
+			if current_page >= result.total_pages:
+				break
+			current_page += 1
+
+		return SimpleNamespace(data=all_workspaces)
+
+	def list_folders(self, workspace_id, page_size=None, page=None, include_all=None):
+		"""List top-level folders in a workspace.
+
+		Replaces deprecated GET /workspaces/{id}/folders and the deprecated
+		includeAll parameter. Always returns all folders via token-based pagination.
+
+		Returns:
+			SimpleNamespace with .data containing a list of Folder objects.
+		"""
+		children = _get_container_children(
+			self._base, "/workspaces/" + str(workspace_id) + "/children"
+		)
+		folders = [Folder(item, self._base) for item in children.folders]
+		return SimpleNamespace(data=folders)
 
 	def list_sheets_in_workspace(
 		self,


### PR DESCRIPTION
Replaces all Smartsheet APIs deprecated/sunset as of Jun-15-2026 with their
new equivalents. All changes are in the smartools library — no changes required
in consuming codebases. Old method signatures are preserved for backward
compatibility.

**ER-00677 / ER-00863 — Unified Sharing API**
- Replaced all deprecated per-asset sharing endpoints with the new unified
  `POST/GET/PATCH/DELETE /shares` API (with `assetType` + `assetId` params)
- Added `SmartoolsSharing` class for direct unified API access
- Added backward-compat wrappers on `Sheets`, `Workspaces`, `Reports`, `Sights`
  so existing callers (`share_sheet`, `list_shares`, `update_share`, etc.) work
  without any code changes
- Added `SmartoolsShare` model to handle string `userId`/`groupId` returned by
  new API (old API returned integers)
- Added `SmartoolsAssetSharesPaginatedResult` model for new paginated share responses

**ER-00864 — Workspace & Folder Endpoints**
- Replaced deprecated `GET /workspaces/{id}` with `/metadata` + `/children`
- Replaced deprecated `GET /folders/{id}` with `/metadata` + `/children`
- Replaced deprecated `GET /workspaces/{id}/folders` and `GET /folders/{id}/folders`
  with `/children` endpoint, using token-based pagination
- Replaced deprecated `includeAll` param in `list_workspaces` with automatic
  page iteration
- Added `SmartoolsContainerChildren` model to parse paginated `/children` responses

## Type of Change

- [x] Feature — new functionality
- [x] Bugfix — fixes an existing issue
- [ ] Hotfix — urgent fix
- [ ] Refactor — code restructuring, no behavior change
- [ ] Docs — documentation updates
- [ ] Chore — CI, dependencies, tooling, etc.

## Checklist

- [x] Manual testing performed
- [x] My branch follows the naming convention (`ER-XXXXXX`)
- [ ] I have run pre-commit checks locally
- [x] I have added/updated tests as appropriate
- [x] I have updated documentation as needed
- [x] My changes do not introduce new warnings or errors
